### PR TITLE
Swap the identifier and direction for ORDER BYs

### DIFF
--- a/database/lib/src/sql/sql_client_table_selection_helper.dart
+++ b/database/lib/src/sql/sql_client_table_selection_helper.dart
@@ -217,7 +217,7 @@ class SqlClientTableSelectionHelper {
         }
         comma = true;
         b.identifier(item.name);
-        b.write(item.isDescending ? 'DESC ' : 'ASC ');
+        b.write(item.isDescending ? ' DESC ' : ' ASC ');
       }
     }
 

--- a/database/lib/src/sql/sql_client_table_selection_helper.dart
+++ b/database/lib/src/sql/sql_client_table_selection_helper.dart
@@ -216,8 +216,8 @@ class SqlClientTableSelectionHelper {
           b.write(', ');
         }
         comma = true;
-        b.write(item.isDescending ? 'DESC ' : 'ASC ');
         b.identifier(item.name);
+        b.write(item.isDescending ? 'DESC ' : 'ASC ');
       }
     }
 


### PR DESCRIPTION
The original solution creates SQL queries as follows:
`SELECT column1, column2, ... FROM ... WHERE ... ORDER BY DESC/ASC column1`
This is incorrect syntax, PostgreSQL will actually throw an exception about it. The correct syntax should be:
`SELECT column1, column2, ... FROM ... WHERE ... ORDER BY column1 DESC/ASC `